### PR TITLE
Fixed archetype trained skills for cleric, druid, sorcerer, and wizard

### DIFF
--- a/src/units/pathfinder2/core/archetype/class/archetype-cleric.yml
+++ b/src/units/pathfinder2/core/archetype/class/archetype-cleric.yml
@@ -4,9 +4,7 @@ group: "_{Core Rulebook}"
 name: "_{Cleric}"
 
 inc:
-  - set: occultism-proficiency
-    value: trained
-  - set: performance-proficiency
+  - set: religion-proficiency
     value: trained
 
   - at: '@archetypes'
@@ -51,7 +49,7 @@ inc:
                     flex: small
                     contents:
                       - paste: anathema
-                      
+
                   - section: "_{Dogmas}"
                     mark: cleric
                     contents:

--- a/src/units/pathfinder2/core/archetype/class/archetype-druid.yml
+++ b/src/units/pathfinder2/core/archetype/class/archetype-druid.yml
@@ -4,9 +4,7 @@ group: "_{Core Rulebook}"
 name: "_{Druid}"
 
 inc:
-  - set: occultism-proficiency
-    value: trained
-  - set: performance-proficiency
+  - set: nature-proficiency
     value: trained
 
   - at: '@archetypes'

--- a/src/units/pathfinder2/core/archetype/class/archetype-sorcerer.yml
+++ b/src/units/pathfinder2/core/archetype/class/archetype-sorcerer.yml
@@ -4,11 +4,6 @@ group: "_{Core Rulebook}"
 name: "_{Sorcerer}"
 
 inc:
-  - set: occultism-proficiency
-    value: trained
-  - set: performance-proficiency
-    value: trained
-
   - at: '@archetypes'
     add:
       - name: "_{Sorcerer}"

--- a/src/units/pathfinder2/core/archetype/class/archetype-wizard.yml
+++ b/src/units/pathfinder2/core/archetype/class/archetype-wizard.yml
@@ -4,9 +4,7 @@ group: "_{Core Rulebook}"
 name: "_{Wizard}"
 
 inc:
-  - set: occultism-proficiency
-    value: trained
-  - set: performance-proficiency
+  - set: arcana-proficiency
     value: trained
 
   - at: '@archetypes'


### PR DESCRIPTION
I found that all casting archetype classes had the bard archetype skill trainings set. I updated the non-bard casting classes with their appropriate default trained skills.