### PR TITLE
Update alchemist-research-field-chirurgeon.yml

### DIFF
--- a/src/units/pathfinder2/core/class/alchemist/research-field/alchemist-research-field-chirurgeon.yml
+++ b/src/units/pathfinder2/core/class/alchemist/research-field/alchemist-research-field-chirurgeon.yml
@@ -34,7 +34,7 @@ inc:
       - level: 13
         contents:
           - h5: "_{Greater Field Discovery}"
-          - p: "_{Increase splash area to 10ft (or 15ft if you have Expanded Splash).}"
+          - p: "_{When using Quick Alchemy to create any elixir of life, the creature drinking it gains the maximum HP possible for that elixir}"
 
   - at: '@alchemist/formulas'
     replace:


### PR DESCRIPTION
Resolved issue where the chirurgeon Greater Field Discovery was incorrectly labeled as the bomber Greater Field Discovery