### PR TITLE
Update attribute boost description for remaster

### DIFF
--- a/src/units/pathfinder2remaster/player-core/option/option-level-up.yml
+++ b/src/units/pathfinder2remaster/player-core/option/option-level-up.yml
@@ -48,7 +48,7 @@ inc:
                         pad: true
                         contents:
                           - h5: "_{Attribute boost}"
-                          - p: "_{At levels 5, 10, 15 and 20, boost 4 different attribute scores. Increase by 1 if the score is already 18 or above, or 2 if not.}"
+                          - p: "_{At levels 5, 10, 15 and 20, boost 4 different attribute scores. Partial boost if above +4, +1 otherwise.}"
 
                       - g:
                         pad: true   


### PR DESCRIPTION
In remaster, attribute boosts do not go to 18 etc, so this text should be updated to take into account partial boost