### PR TITLE
Inline generate character script

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:bundle": "rollup src/lib/lib.js --file src/lib-charactersheets.js --format cjs --external fs",
     "build:compile": "babel src/lib-charactersheets.js -d lib",
     "build:unitgen": "node src/make/unitgen/unitGen.js",
+    "build:safe": "npm run build:units && npm run build:bundle && npm run build:compile",
     "docs": "npm run docs:contrib && npm run docs:jsdoc",
     "docs:jsdoc": "npx jsdoc -d docs/api src/lib",
     "docs:contrib": "npx gitbook build src/docs docs",
@@ -49,6 +50,7 @@
     "test:i18n": "node test/i18n.js",
     "test:i18n:clean": "rm -r test/out/i18n",
     "test:preview": "node test/test-preview.js",
+    "generate": "node test/generate-character.js",
     "test": "npm run build && node test/test.js"
   },
   "license": "Artistic-2.0",

--- a/test/generate-character.config.json
+++ b/test/generate-character.config.json
@@ -11,6 +11,7 @@
       "druid": "untamed"
     },
     "feats": ["diehard"],
+    "archetypes": [],
     "language": "en"
   },
 

--- a/test/generate-character.config.json
+++ b/test/generate-character.config.json
@@ -2,7 +2,7 @@
   "game": "pathfinder2remaster",
 
   "identity": {
-    "name": "",
+    "name": "Bartholomew, Sir Longbottom",
     "ancestry": "human",
     "heritage": "versatile",
     "background": "noble",

--- a/test/generate-character.config.json
+++ b/test/generate-character.config.json
@@ -1,0 +1,41 @@
+{
+  "game": "pathfinder2remaster",
+
+  "identity": {
+    "name": "",
+    "ancestry": "human",
+    "heritage": "versatile",
+    "background": "noble",
+    "classes": ["druid"],
+    "subclasses": {
+      "druid": "untamed"
+    },
+    "feats": ["diehard"],
+    "language": "en"
+  },
+
+  "attributes": {
+    "inventoryStyle": "double",
+    "optionCover": true,
+    "optionPermission": true,
+    "optionReference": true,
+    "optionBuild": true,
+    "optionMinis": true,
+    "optionBackground": true,
+    "optionLevelUp": true,
+    "optionColourful": true,
+    "optionPfs": false,
+    "optionAncestryParagon": false,
+    "optionAutomaticBonusProgression": false,
+    "skillsGroup": true,
+    "skillActions": true,
+    "miniSize": "small",
+    "printColour": "#241428",
+    "accentColour": "#a6085e",
+    "printDyslexic": false,
+    "printDyslexie": true,
+    "printPortrait": "portraits/Gnome Noole.png",
+    "printLogo": "logos/pathfinder2e.png",
+    "printBackground": "backgrounds/paper3.jpg"
+  }
+}

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
-// node test/generate-character.js
+// node test/generate-character.js [flags]
+// --game, --name, --ancestry, --heritage, --background, --subclass, --language, --out
+// --class druid|cleric <or> --class druid --class cleric
+// --feat is be repeatable as well
 
 const fs = require('fs');
 const path = require('path');
@@ -47,6 +50,33 @@ function subclassSlotsOf(classValue) {
   return (classValue.selects || []).filter(name => !name.startsWith('feat/'));
 }
 
+function parseArgs(argv) {
+  const args = { feats: [], classes: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+
+    const key = arg.slice(2);
+    const value = argv[i + 1];
+    i++;
+
+    switch (key) {
+      case 'game': args.game = value; break;
+      case 'name': args.name = value; break;
+      case 'ancestry': args.ancestry = value; break;
+      case 'heritage': args.heritage = value; break;
+      case 'background': args.background = value; break;
+      case 'class': args.classes.push(...value.split('|')); break;
+      case 'subclass': args.subclass = value; break;
+      case 'feat': args.feats.push(value); break;
+      case 'language': args.language = value; break;
+      case 'out': args.out = value; break;
+      default: console.error(`generate-character: unknown flag --${key}`); process.exit(1);
+    }
+  }
+  return args;
+}
+
 /*
   "identity": {
     "name": "",
@@ -87,15 +117,17 @@ function attributesForIdentity(identity, config, game) {
   attributes.background = resolveValue(findSlot(data, 'background'), identity.background).id;
 
   // class
-  const classValue = resolveValue(findSlot(data, 'class'), identity.classes[0]);
-  attributes.classes = [classValue.id];
+  const classValues = identity.classes.map(code => resolveValue(findSlot(data, 'class'), code));
+  attributes.classes = classValues.map(cv => cv.id);
 
-  // subclass
-  const [subclassSlotName] = subclassSlotsOf(classValue);
-  if (subclassSlotName) {
+  // subclass,
+  classValues.forEach(classValue => {
+    const [subclassSlotName] = subclassSlotsOf(classValue);
+    if (!subclassSlotName) return;
     const subclassCode = identity.subclasses[removeRemasterPrefix(classValue.code)];
+    if (!subclassCode) return;
     attributes[subclassSlotName] = resolveValue(findSlot(data, subclassSlotName), subclassCode).id;
-  }
+  });
 
   // feats
   if (identity.feats && identity.feats.length) {
@@ -109,12 +141,25 @@ function attributesForIdentity(identity, config, game) {
 }
 
 function main() {
+  const args = parseArgs(process.argv.slice(2));
   const config = loadConfig();
-  const game = config.game;
-  const identity = config.identity;
+  const game = args.game || config.game;
+
+  const identity = { ...config.identity };
+  if (args.name) identity.name = args.name;
+  if (args.ancestry) identity.ancestry = args.ancestry;
+  if (args.heritage) identity.heritage = args.heritage;
+  if (args.background) identity.background = args.background;
+  if (args.classes.length) identity.classes = args.classes;
+  if (args.subclass) {
+    const classCode = identity.classes[0];
+    identity.subclasses = { ...identity.subclasses, [classCode]: args.subclass };
+  }
+  if (args.language) identity.language = args.language;
+  if (args.feats.length) identity.feats = args.feats;
 
   const attributes = attributesForIdentity(identity, config, game);
-  const name = identity.name || game;
+  const name = args.out || identity.name || game;
 
   const request = {
     version: 0,

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -2,8 +2,8 @@
 
 // node test/generate-character.js [flags]
 // --game, --name, --ancestry, --heritage, --background, --subclass, --language, --out
-// --class druid|cleric <or> --class druid --class cleric
-// --feat is be repeatable as well
+// --class (alias: --classes) --feat (alias: --feats)
+// --class druid|cleric <or> --class druid,cleric <or> --class druid --class cleric
 
 const fs = require('fs');
 const path = require('path');
@@ -50,6 +50,10 @@ function subclassSlotsOf(classValue) {
   return (classValue.selects || []).filter(name => !name.startsWith('feat/'));
 }
 
+function splitMultiflag(value) {
+  return value.split(/[|,]/);
+}
+
 function parseArgs(argv) {
   const args = { feats: [], classes: [] };
   for (let i = 0; i < argv.length; i++) {
@@ -66,9 +70,11 @@ function parseArgs(argv) {
       case 'ancestry': args.ancestry = value; break;
       case 'heritage': args.heritage = value; break;
       case 'background': args.background = value; break;
-      case 'class': args.classes.push(...value.split('|')); break;
+      case 'class':
+      case 'classes': args.classes.push(...splitMultiflag(value)); break;
       case 'subclass': args.subclass = value; break;
-      case 'feat': args.feats.push(value); break;
+      case 'feat':
+      case 'feats': args.feats.push(...splitMultiflag(value)); break;
       case 'language': args.language = value; break;
       case 'out': args.out = value; break;
       default: console.error(`generate-character: unknown flag --${key}`); process.exit(1);

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -4,13 +4,18 @@
 // --game, --name, --ancestry, --heritage, --background, --subclass, --language, --out
 // --class (alias: --classes) --feat (alias: --feats)
 // --class druid|cleric <or> --class druid,cleric <or> --class druid --class cleric
+// --render | create test/out/<name>.html
+// --open | autoopen rendered file 
+// --no-build | no library rebuild (faster if no changes)
 
 const fs = require('fs');
 const path = require('path');
+const { execSync, exec } = require('child_process');
 
 const REPO_ROOT = path.join(__dirname, '..');
 const LIB_DIR = path.join(REPO_ROOT, 'lib');
 const IN_DIR = path.join(__dirname, 'in');
+const OUT_DIR = path.join(__dirname, 'out');
 const CONFIG_PATH = path.join(__dirname, 'generate-character.config.json');
 
 function loadConfig() {
@@ -54,6 +59,12 @@ function splitMultiflag(value) {
   return value.split(/[|,]/);
 }
 
+const BOOLEAN_FLAGS = new Set([
+  'render',
+  'open',
+  'no-build'
+]);
+
 function parseArgs(argv) {
   const args = { feats: [], classes: [] };
   for (let i = 0; i < argv.length; i++) {
@@ -61,8 +72,13 @@ function parseArgs(argv) {
     if (!arg.startsWith('--')) continue;
 
     const key = arg.slice(2);
-    const value = argv[i + 1];
-    i++;
+    let value;
+    if (BOOLEAN_FLAGS.has(key)) {
+      value = true;
+    } else {
+      value = argv[i + 1];
+      i++;
+    }
 
     switch (key) {
       case 'game': args.game = value; break;
@@ -77,6 +93,9 @@ function parseArgs(argv) {
       case 'feats': args.feats.push(...splitMultiflag(value)); break;
       case 'language': args.language = value; break;
       case 'out': args.out = value; break;
+      case 'render': args.render = true; break;
+      case 'open': args.open = true; break;
+      case 'no-build': args.noBuild = true; break;
       default: console.error(`generate-character: unknown flag --${key}`); process.exit(1);
     }
   }
@@ -146,6 +165,84 @@ function attributesForIdentity(identity, config, game) {
   return attributes;
 }
 
+// send the rebuild to existing build script
+function rebuildLibrary(noBuild) {
+  if (noBuild) return;
+  execSync('npm run build', { cwd: REPO_ROOT, stdio: 'inherit' });
+}
+
+// make the setup in test.js into a function, otherwise it's identical
+let characterSheets = null;
+function getCharacterSheets() {
+  if (!characterSheets) {
+    characterSheets = require(path.join(LIB_DIR, 'lib-charactersheets.js'));
+    characterSheets.addAssetsDir(path.join(IN_DIR, 'assets'));
+    characterSheets.translationsPromise = characterSheets.loadDefaultTranslations();
+  }
+  return characterSheets;
+}
+
+// standard open-file per OS function borrowed from the internet
+function openFile(filePath) {
+  // macOS
+  if (process.platform === 'darwin') {
+    exec(`open "${filePath}"`);
+    return;
+  }
+
+  // Windows
+  if (process.platform === 'win32') {
+    exec(`start "" "${filePath}"`);
+    return;
+  }
+
+  // WSL 
+  const isWsl = fs.existsSync('/proc/version')
+    && fs.readFileSync('/proc/version', 'utf-8').toLowerCase().includes('microsoft');
+  if (isWsl) {
+    const winPath = execSync(`wslpath -w "${filePath}"`).toString().trim();
+    exec(`explorer.exe "${winPath}"`);
+    return;
+  }
+  
+  // Unix
+  exec(`xdg-open "${filePath}"`);
+}
+
+// same shape as saveResult in test.js
+function saveResult(result, openFlag) {
+  if (Array.isArray(result)) {
+    result.forEach(r => saveResult(r, openFlag));
+    return;
+  }
+
+  if (result.err) {
+    console.error('generate-character: render error', result.err);
+    return;
+  }
+
+  const outfile = path.join(OUT_DIR, result.filename);
+  fs.writeFileSync(outfile, result.data);
+  console.log(`Rendered ${path.relative(process.cwd(), outfile)}`);
+  
+  // open if user requested
+  if (openFlag) 
+    openFile(outfile);
+}
+
+function renderToOut(request, openFlag) {
+  const characterSheets = getCharacterSheets();
+  
+  return characterSheets.translationsPromise.then(() => characterSheets.create(request)).then(result => {
+    if (result === null) {
+      console.error('generate-character: render produced nothing (skipped)');
+      return;
+    }
+    
+    saveResult(result, openFlag);
+  });
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const config = loadConfig();
@@ -182,9 +279,19 @@ function main() {
   const outFile = path.join(IN_DIR, `${name}.json`);
   fs.writeFileSync(outFile, JSON.stringify(request, null, 2));
   console.log(`Wrote ${path.relative(process.cwd(), outFile)}`);
+
+  if (!args.render) {
+    return Promise.resolve();
+  }
+
+  rebuildLibrary(args.noBuild);
+  return renderToOut(request, args.open);
 }
 
-main();
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 /*
 

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -4,10 +4,11 @@
 // --game, --name, --ancestry, --heritage, --background, --subclass, --language, --out
 // --class (alias: --classes) --feat (alias: --feats) --archetype (alias: --archetypes)
 // --class druid|cleric <or> --class druid,cleric <or> --class druid --class cleric
-// --overwrite key=value (aliases: --overwrites, --set, --setarg, --setargs, --kwargs) 
+// --kwargs key=value | overwrite any attribute
 // --render | create test/out/<name>.html
 // --open | autoopen rendered file 
 // --no-build | no library rebuild (faster if no changes)
+// --list <subgroup> | list all valid values for ancestry/heritage/background/class/subclass/archetype/language
 
 const fs = require('fs');
 const path = require('path');
@@ -56,6 +57,20 @@ function subclassSlotsOf(classValue) {
   return (classValue.selects || []).filter(name => !name.startsWith('feat/'));
 }
 
+function listSlotValues(slot, label) {
+  console.log(`${label}:`);
+  slot.values
+    .map(v => ({
+      code: removeRemasterPrefix(v.code),
+      name: removeTranslationKey(v.name),
+      group: removeTranslationKey(v.group || ''),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .forEach(v => {
+      console.log(`  ${v.code.padEnd(30)} ${v.name}${v.group ? ` (${v.group})` : ''}`);
+    });
+}
+
 function splitMultiflag(value) {
   return value.split(/[|,]/);
 }
@@ -67,7 +82,7 @@ const BOOLEAN_FLAGS = new Set([
 ]);
 
 function parseArgs(argv) {
-  const args = { feats: [], classes: [], archetypes: [], overwrites: [] };
+  const args = { feats: [], classes: [], archetypes: [], kwargs: [] };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (!arg.startsWith('--')) continue;
@@ -94,14 +109,10 @@ function parseArgs(argv) {
       case 'feats': args.feats.push(...splitMultiflag(value)); break;
       case 'archetype':
       case 'archetypes': args.archetypes.push(...splitMultiflag(value)); break;
-      case 'set':
-      case 'setarg':
-      case 'setargs':
-      case 'kwargs':
-      case 'overwrite':
-      case 'overwrites': args.overwrites.push(value); break;
+      case 'kwargs': args.kwargs.push(value); break;
       case 'language': args.language = value; break;
       case 'out': args.out = value; break;
+      case 'list': args.list = value; break;
       case 'render': args.render = true; break;
       case 'open': args.open = true; break;
       case 'no-build': args.noBuild = true; break;
@@ -179,6 +190,55 @@ function attributesForIdentity(identity, config, game) {
   attributes.language = resolveLanguage(data, identity.language).code;
 
   return attributes;
+}
+
+// config.identity plus whatever the CLI overwrites
+function buildIdentity(args, config) {
+  const identity = { ...config.identity };
+  if (args.name) identity.name = args.name;
+  if (args.ancestry) identity.ancestry = args.ancestry;
+  if (args.heritage) identity.heritage = args.heritage;
+  if (args.background) identity.background = args.background;
+  if (args.classes.length) identity.classes = args.classes;
+  if (args.subclass) {
+    const classCode = identity.classes[0];
+    identity.subclasses = { ...identity.subclasses, [classCode]: args.subclass };
+  }
+  if (args.language) identity.language = args.language;
+  if (args.feats.length) identity.feats = args.feats;
+  if (args.archetypes.length) identity.archetypes = args.archetypes;
+  return identity;
+}
+
+// apply kwargs into the attributes object
+function applyKwargs(attributes, kwargs) {
+  kwargs.forEach(raw => {
+    const eq = raw.indexOf('=');
+    const key = raw.slice(0, eq);
+    const value = raw.slice(eq + 1);
+    attributes[key] = value;
+  });
+}
+
+// build json object to send
+function buildRequest(attributes) {
+  return {
+    version: 0,
+    data: {
+      type: 'character',
+      id: Math.random().toString(16).slice(2, 9),
+      isLoggedIn: true,
+      attributes,
+    },
+  };
+}
+
+// this creates the .json request file to then render
+// the character sheet, following the same conventions the site does
+function writeRequestFile(name, request) {
+  const outFile = path.join(IN_DIR, `${name}.json`);
+  fs.writeFileSync(outFile, JSON.stringify(request, null, 2));
+  console.log(`Wrote ${path.relative(process.cwd(), outFile)}`);
 }
 
 // send the rebuild to existing build script
@@ -259,52 +319,69 @@ function renderToOut(request, openFlag) {
   });
 }
 
+function runList(args, game) {
+  const data = loadData(game);
+
+  if (args.list === 'language') {
+    console.log('language:');
+    data.languages
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .forEach(l => console.log(`  ${l.code.padEnd(10)} ${l.name}`));
+    return;
+  }
+
+  if (args.list === 'heritage') {
+    if (!args.ancestry) {
+      console.error('generate-character: --list heritage needs --ancestry');
+      process.exit(1);
+    }
+    const ancestryValue = resolveValue(findSlot(data, 'ancestry'), args.ancestry);
+    const heritageSlotName = ancestryValue.selects.find(n => n.startsWith('heritage/'));
+    listSlotValues(findSlot(data, heritageSlotName), `heritage (${removeTranslationKey(ancestryValue.name)})`);
+    return;
+  }
+
+  if (args.list === 'subclass') {
+    if (args.classes.length !== 1) {
+      console.error('generate-character: --list subclass needs exactly one --class');
+      process.exit(1);
+    }
+    const classValue = resolveValue(findSlot(data, 'class'), args.classes[0]);
+    const slotNames = subclassSlotsOf(classValue);
+    if (slotNames.length === 0) {
+      console.log(`${removeTranslationKey(classValue.name)} has no subclass slot`);
+    }
+    slotNames.forEach(slotName => listSlotValues(findSlot(data, slotName), slotName));
+    return;
+  }
+
+  if (['ancestry', 'background', 'class', 'archetype'].includes(args.list)) {
+    listSlotValues(findSlot(data, args.list), args.list);
+    return;
+  }
+
+  console.error(`generate-character: --list ${args.list} uses ancestry, heritage, background, class, subclass, archetype, or language`);
+  process.exit(1);
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const config = loadConfig();
   const game = args.game || config.game;
 
-  const identity = { ...config.identity };
-  if (args.name) identity.name = args.name;
-  if (args.ancestry) identity.ancestry = args.ancestry;
-  if (args.heritage) identity.heritage = args.heritage;
-  if (args.background) identity.background = args.background;
-  if (args.classes.length) identity.classes = args.classes;
-  if (args.subclass) {
-    const classCode = identity.classes[0];
-    identity.subclasses = { ...identity.subclasses, [classCode]: args.subclass };
+  if (args.list) {
+    runList(args, game);
+    return Promise.resolve();
   }
-  if (args.language) identity.language = args.language;
-  if (args.feats.length) identity.feats = args.feats;
-  if (args.archetypes.length) identity.archetypes = args.archetypes;
 
+  const identity = buildIdentity(args, config);
   const attributes = attributesForIdentity(identity, config, game);
-
-  // overwrite any field in the attributes via key=value after the flag 
-  args.overwrites.forEach(raw => {
-    const eq = raw.indexOf('=');
-    const key = raw.slice(0, eq);
-    const value = raw.slice(eq + 1);
-    attributes[key] = value;
-  });
+  applyKwargs(attributes, args.kwargs);
 
   const name = args.out || identity.name || game;
-
-  const request = {
-    version: 0,
-    data: {
-      type: 'character',
-      id: Math.random().toString(16).slice(2, 9),
-      isLoggedIn: true,
-      attributes,
-    },
-  };
-
-  // this creates the .json request file to then render
-  // the character sheet, following the same conventions the site does
-  const outFile = path.join(IN_DIR, `${name}.json`);
-  fs.writeFileSync(outFile, JSON.stringify(request, null, 2));
-  console.log(`Wrote ${path.relative(process.cwd(), outFile)}`);
+  const request = buildRequest(attributes);
+  writeRequestFile(name, request);
 
   if (!args.render) {
     return Promise.resolve();

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -332,9 +332,9 @@ function openFile(filePath) {
 }
 
 // same shape as saveResult in test.js
-function saveResult(result, openFlag) {
+function saveResult(result, name, openFlag) {
   if (Array.isArray(result)) {
-    result.forEach(r => saveResult(r, openFlag));
+    result.forEach(r => saveResult(r, name, openFlag));
     return;
   }
 
@@ -344,25 +344,25 @@ function saveResult(result, openFlag) {
   }
 
   fs.mkdirSync(HTML_DIR, { recursive: true });
-  const outfile = path.join(HTML_DIR, result.filename);
+  const outfile = path.join(HTML_DIR, `${name} - ${result.filename}`);
   fs.writeFileSync(outfile, result.data);
   console.log(`Rendered ${path.relative(process.cwd(), outfile)}`);
-  
+
   // open if user requested
-  if (openFlag) 
+  if (openFlag)
     openFile(outfile);
 }
 
-function renderToOut(request, openFlag) {
+function renderToOut(request, name, openFlag) {
   const characterSheets = getCharacterSheets();
-  
+
   return characterSheets.translationsPromise.then(() => characterSheets.create(request)).then(result => {
     if (result === null) {
       console.error('generate-character: render produced nothing (skipped)');
       return;
     }
-    
-    saveResult(result, openFlag);
+
+    saveResult(result, name, openFlag);
   });
 }
 
@@ -569,7 +569,7 @@ function main() {
   }
 
   rebuildLibrary(args.noBuild);
-  return requests.reduce((chain, { request }) => chain.then(() => renderToOut(request, args.open)), Promise.resolve());
+  return requests.reduce((chain, { name, request }) => chain.then(() => renderToOut(request, name, args.open)), Promise.resolve());
 }
 
 main().catch(err => {

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -39,7 +39,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync, exec } = require('child_process');
+const { execSync, execFileSync, execFile } = require('child_process');
 const cheerio = require('cheerio');
 
 const REPO_ROOT = path.join(__dirname, '..');
@@ -315,30 +315,32 @@ function getCharacterSheets() {
 }
 
 // standard open-file per OS function borrowed from the internet
+// uses execFile (argv array, no shell) throughout so filenames with commas/spaces/etc.
+// can't get mangled by manual shell-string quoting
 function openFile(filePath) {
   // macOS
   if (process.platform === 'darwin') {
-    exec(`open "${filePath}"`);
+    execFile('open', [filePath]);
     return;
   }
 
   // Windows
   if (process.platform === 'win32') {
-    exec(`start "" "${filePath}"`);
+    execFile('cmd.exe', ['/c', 'start', '', filePath]);
     return;
   }
 
-  // WSL 
+  // WSL
   const isWsl = fs.existsSync('/proc/version')
     && fs.readFileSync('/proc/version', 'utf-8').toLowerCase().includes('microsoft');
   if (isWsl) {
-    const winPath = execSync(`wslpath -w "${filePath}"`).toString().trim();
-    exec(`explorer.exe "${winPath}"`);
+    const winPath = execFileSync('wslpath', ['-w', filePath]).toString().trim();
+    execFile('explorer.exe', [winPath]);
     return;
   }
-  
+
   // Unix
-  exec(`xdg-open "${filePath}"`);
+  execFile('xdg-open', [filePath]);
 }
 
 function filterToPages(html, pageIndexes) {

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -27,6 +27,9 @@
 // --limit <integer>                      | limit the number of files that can generate at once above default
 // --kwargs key=value                     | overwrite any attribute
 // --render                               | create test/out/html/<filename>.html
+// --page                                 | only keep these pages (1 = the character page,
+//                                          then combat/feats/class/etc) + 0, -1, -2... allow to
+//                                          access pages before, may be non-consecutive: --page -1,2,6
 // --open                                 | autoopen rendered file
 // --out <name>                           | when only one file is generated, this replaces the filename
 //                                          when multiple values generate fileS, it's a prefix instead
@@ -37,6 +40,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync, exec } = require('child_process');
+const cheerio = require('cheerio');
 
 const REPO_ROOT = path.join(__dirname, '..');
 const LIB_DIR = path.join(REPO_ROOT, 'lib');
@@ -150,6 +154,7 @@ function parseArgs(argv) {
     heritages: [],
     backgrounds: [],
     languages: [],
+    pages: [],
   };
 
   for (let i = 0; i < argv.length; i++) {
@@ -189,6 +194,8 @@ function parseArgs(argv) {
       case 'out': args.out = value; break;
       case 'list': args.list = value; break;
       case 'limit': args.limit = parseInt(value, 10); break;
+      case 'page':
+      case 'pages': args.pages.push(...splitMultiflag(value).map(v => parseInt(v, 10))); break;
       case 'render': args.render = true; break;
       case 'open': args.open = true; break;
       case 'no-build': args.noBuild = true; break;
@@ -334,10 +341,45 @@ function openFile(filePath) {
   exec(`xdg-open "${filePath}"`);
 }
 
+function filterToPages(html, pageIndexes) {
+  const $ = cheerio.load(html, { decodeEntities: false });
+
+  // pages aren't straight-forward, so this workaround is required
+  const pageIds = $('.page-container').map((i, el) => $(el).children('[data-page]').first().attr('data-page')).get();
+
+  let anchorId = null;
+  $('.index-button').each((i, el) => {
+    const $el = $(el);
+    if ($el.find('.index-button__number').text().trim() === '1') anchorId = $el.attr('data-page');
+  });
+  const anchorPos = pageIds.indexOf(anchorId);
+
+  const targetPageIds = new Set();
+  const missing = [];
+  pageIndexes.forEach(pageIndex => {
+    const targetPageId = pageIds[anchorPos + (pageIndex - 1)];
+    if (anchorPos === -1 || targetPageId === undefined) missing.push(pageIndex);
+    else targetPageIds.add(targetPageId);
+  });
+
+  if (missing.length) console.error(`generate-character: --page ${missing.join(',')} not found`);
+  if (!targetPageIds.size) return html;
+
+  $('.page-container').each((i, el) => {
+    const $el = $(el);
+    if (!targetPageIds.has($el.children('[data-page]').first().attr('data-page'))) {
+      $el.remove();
+    }
+  });
+  $('#index-buttons').remove();
+
+  return $.html();
+}
+
 // same shape as saveResult in test.js
-function saveResult(result, name, openFlag) {
+function saveResult(result, name, openFlag, pages) {
   if (Array.isArray(result)) {
-    result.forEach(r => saveResult(r, name, openFlag));
+    result.forEach(r => saveResult(r, name, openFlag, pages));
     return;
   }
 
@@ -346,9 +388,11 @@ function saveResult(result, name, openFlag) {
     return;
   }
 
+  const data = pages.length ? filterToPages(result.data, pages) : result.data;
+
   fs.mkdirSync(HTML_DIR, { recursive: true });
   const outfile = path.join(HTML_DIR, `${name} - ${result.filename}`);
-  fs.writeFileSync(outfile, result.data);
+  fs.writeFileSync(outfile, data);
   console.log(`Rendered ${path.relative(process.cwd(), outfile)}`);
 
   // open if user requested
@@ -356,7 +400,7 @@ function saveResult(result, name, openFlag) {
     openFile(outfile);
 }
 
-function renderToOut(request, name, openFlag) {
+function renderToOut(request, name, openFlag, pages) {
   const characterSheets = getCharacterSheets();
 
   return characterSheets.translationsPromise.then(() => characterSheets.create(request)).then(result => {
@@ -365,7 +409,7 @@ function renderToOut(request, name, openFlag) {
       return;
     }
 
-    saveResult(result, name, openFlag);
+    saveResult(result, name, openFlag, pages);
   });
 }
 
@@ -572,7 +616,7 @@ function main() {
   }
 
   rebuildLibrary(args.noBuild);
-  return requests.reduce((chain, { name, request }) => chain.then(() => renderToOut(request, name, args.open)), Promise.resolve());
+  return requests.reduce((chain, { name, request }) => chain.then(() => renderToOut(request, name, args.open, args.pages)), Promise.resolve());
 }
 
 main().catch(err => {

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -3,7 +3,7 @@
 // node test/generate-character.js --<flags>
 // node generate --flag1 arg1,arg2,arg3,...,argN --flag2 arg
 // via npm: npm run generate -- --flag1 arg1 --flag2 arg2
-//          (the "--" before the flags is required, otherwise npm swallows them)
+//          !!! the "--" before the flags is required, otherwise npm swallows them !!!
 //
 // accepted separators: , ; |
 //
@@ -47,6 +47,9 @@ const HTML_DIR = path.join(OUT_DIR, 'html');
 const CONFIG_PATH = path.join(__dirname, 'generate-character.config.json');
 
 const DEFAULT_LIMIT = 200;
+const DEFAULT_CHARSHEET_PREFIX = 'charsheet';
+const REMASTER_PREFIX = 'remaster-'
+const SEPARATORS = ",;|"
 
 function loadConfig() {
   return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
@@ -67,7 +70,7 @@ function removeTranslationKey(name) {
 }
 
 function removeRemasterPrefix(code) {
-  return code.startsWith('remaster-') ? code.slice('remaster-'.length) : code;
+  return code.startsWith(REMASTER_PREFIX) ? code.slice(REMASTER_PREFIX.length) : code;
 }
 
 function resolveValue(slot, input) {
@@ -118,7 +121,7 @@ function listSlotValues(slot, label) {
 }
 
 function splitMultiflag(value) {
-  return value.split(/[,;|]/);
+  return value.split(new RegExp(SEPARATORS));
 }
 
 // classic cartesian product
@@ -148,6 +151,7 @@ function parseArgs(argv) {
     backgrounds: [],
     languages: [],
   };
+
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (!arg.startsWith('--')) continue;
@@ -162,8 +166,7 @@ function parseArgs(argv) {
     }
 
     switch (key) {
-      case 'game':
-      case 'games': args.games.push(...splitMultiflag(value)); break;
+      case 'game': case 'games': args.games.push(...splitMultiflag(value)); break;
       case 'name': args.name = value; break;
       case 'ancestry':
       case 'ancestries': args.ancestries.push(...splitMultiflag(value)); break;
@@ -419,7 +422,7 @@ function checkSubclassNeedsOneClass(classVariants, identityClasses, subclassSpec
     ? identityClasses.length
     : classVariants.length;
   if (classCount !== 1) {
-    console.error('generate-character: --subclass needs exactly one class, via --class or a single-class config default');
+    console.error('generate-character: --subclass needs exactly one class');
     process.exit(1);
   }
 }
@@ -472,7 +475,7 @@ function buildCombos(games, variants, identity, args) {
 
 function checkComboLimit(combos, limit) {
   if (combos.length > limit) {
-    console.error(`generate-character: this would generate ${combos.length} new charsheets. Increase the limit to proceed.`);
+    console.error(`generate-character: this would generate ${combos.length} new charsheets. Your computer wouldn't like it, so increase the limit to proceed. You can use --limit <integer> for that.`);
     process.exit(1);
   }
 }
@@ -517,7 +520,7 @@ function nameForCombo(combo, args, identity, multi, multiFlags) {
   }
 
   // generate the filenames based on parts that consitute characters
-  const parts = [args.out || 'char'];
+  const parts = [args.out || DEFAULT_CHARSHEET_PREFIX];
   if (multiFlags.game) parts.push(combo.game);
   if (multiFlags.ancestry) parts.push(combo.ancestry);
   if (multiFlags.heritage) parts.push(combo.heritage);

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+// node test/generate-character.js
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const LIB_DIR = path.join(REPO_ROOT, 'lib');
+const IN_DIR = path.join(__dirname, 'in');
+const CONFIG_PATH = path.join(__dirname, 'generate-character.config.json');
+
+function loadConfig() {
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
+}
+
+function loadData(game) {
+  const dataPath = path.join(LIB_DIR, `data-${game}.json`);
+  return JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+}
+
+function findSlot(data, slotName) {
+  return data.selects.find(s => s.select === slotName);
+}
+
+function removeTranslationKey(name) {
+  const match = /^_\{(.*)\}$/.exec(name);
+  return match ? match[1] : name;
+}
+
+function removeRemasterPrefix(code) {
+  return code.startsWith('remaster-') ? code.slice('remaster-'.length) : code;
+}
+
+function resolveValue(slot, input) {
+  const needle = input.toLowerCase();
+  return slot.values.find(v => v.code === input)
+    || slot.values.find(v => removeRemasterPrefix(v.code) === input)
+    || slot.values.find(v => removeTranslationKey(v.name).toLowerCase() === needle);
+}
+
+function resolveLanguage(data, input) {
+  return data.languages.find(l => l.code === input);
+}
+
+function subclassSlotsOf(classValue) {
+  return (classValue.selects || []).filter(name => !name.startsWith('feat/'));
+}
+
+/*
+  "identity": {
+    "name": "",
+    "ancestry": "human",
+    "heritage": "versatile",
+    "background": "noble",
+    "classes": ["druid"],
+    "subclasses": {
+      "druid": "untamed"
+    },
+    "feats": ["diehard"],
+    "language": "en"
+  },
+*/
+
+// trying not to create a separate attribute for every 
+// subset of differently names subclasses, so the script
+// tries to find the type of slot that fits
+function attributesForIdentity(identity, config, game) {
+  const data = loadData(game);
+  const attributes = { game, ...config.attributes };
+
+  // name
+  attributes.name = identity.name || game;
+
+  // ancestry
+  const ancestryValue = resolveValue(findSlot(data, 'ancestry'), identity.ancestry);
+  attributes.ancestry = ancestryValue.id;
+
+  // heritage
+  const heritageSlotName = (ancestryValue.selects || []).find(name => name.startsWith('heritage/'));
+  if (heritageSlotName) {
+    const heritageValue = resolveValue(findSlot(data, heritageSlotName), identity.heritage);
+    attributes[heritageSlotName] = heritageValue.id;
+  }
+
+  // background
+  attributes.background = resolveValue(findSlot(data, 'background'), identity.background).id;
+
+  // class
+  const classValue = resolveValue(findSlot(data, 'class'), identity.classes[0]);
+  attributes.classes = [classValue.id];
+
+  // subclass
+  const [subclassSlotName] = subclassSlotsOf(classValue);
+  if (subclassSlotName) {
+    const subclassCode = identity.subclasses[removeRemasterPrefix(classValue.code)];
+    attributes[subclassSlotName] = resolveValue(findSlot(data, subclassSlotName), subclassCode).id;
+  }
+
+  // feats
+  if (identity.feats && identity.feats.length) {
+    attributes.feats = identity.feats;
+  }
+
+  // language
+  attributes.language = resolveLanguage(data, identity.language).code;
+
+  return attributes;
+}
+
+function main() {
+  const config = loadConfig();
+  const game = config.game;
+  const identity = config.identity;
+
+  const attributes = attributesForIdentity(identity, config, game);
+  const name = identity.name || game;
+
+  const request = {
+    version: 0,
+    data: {
+      type: 'character',
+      id: Math.random().toString(16).slice(2, 9),
+      isLoggedIn: true,
+      attributes,
+    },
+  };
+
+  // this creates the .json request file to then render
+  // the character sheet, following the same conventions the site does
+  const outFile = path.join(IN_DIR, `${name}.json`);
+  fs.writeFileSync(outFile, JSON.stringify(request, null, 2));
+  console.log(`Wrote ${path.relative(process.cwd(), outFile)}`);
+}
+
+main();
+
+/*
+
+{
+  "version": 0,
+  "data": {
+    "type": "character",
+    "id": "8fa82c7",
+    "isLoggedIn": true,
+    "attributes": {
+      "game": "pathfinder2remaster",
+      "name": "Remaster",
+      "ancestry": "ancestry/remaster/human",
+      "heritage/human": "heritage/human/remaster/versatile",
+      "background": "background/noble",
+      "classes": [
+        "class/remaster/alchemist"
+      ],
+      "cleric/doctrine": "cleric/doctrine/remaster/warpriest",
+      "rogue/racket": "rogue/racket/ruffian",
+      "x/druid/order": "druid/order/remaster/leaf",
+      "witch/patron": "witch/patron/wilding-steward",
+      "wizard/thesis": "wizard/thesis/staff-nexus",
+      "wizard/school": "wizard/school/unified-magical-theory",
+      "archetypes": ["xxx/archetype/remaster/wizard"],
+      "inventoryStyle": "double",
+      "optionCover": true,
+      "optionPermission": true,
+      "optionReference": true,
+      "optionBuild": true,
+      "optionMinis": true,
+      "optionBackground": true,
+      "optionLevelUp": true,
+      "optionColourful": true,
+      "optionPfs": false,
+      "optionAncestryParagon": false,
+      "optionAutomaticBonusProgression": false,
+      "feats": [ "diehard" ],
+      "skillsGroup": true,
+      "skillActions": true,
+      "miniSize": "small",
+      "printColour": "#241428",
+      "accentColour": "#a6085e",
+      "printDyslexic": false,
+      "printDyslexie": true,
+      "printPortrait": "portraits/Gnome Noole.png",
+      "printLogo": "logos/pathfinder2e.png",
+      "printBackground": "backgrounds/paper3.jpg"
+    }
+  }
+}
+
+
+*/

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -2,8 +2,9 @@
 
 // node test/generate-character.js [flags]
 // --game, --name, --ancestry, --heritage, --background, --subclass, --language, --out
-// --class (alias: --classes) --feat (alias: --feats)
+// --class (alias: --classes) --feat (alias: --feats) --archetype (alias: --archetypes)
 // --class druid|cleric <or> --class druid,cleric <or> --class druid --class cleric
+// --overwrite key=value (aliases: --overwrites, --set, --setarg, --setargs, --kwargs) 
 // --render | create test/out/<name>.html
 // --open | autoopen rendered file 
 // --no-build | no library rebuild (faster if no changes)
@@ -66,7 +67,7 @@ const BOOLEAN_FLAGS = new Set([
 ]);
 
 function parseArgs(argv) {
-  const args = { feats: [], classes: [] };
+  const args = { feats: [], classes: [], archetypes: [], overwrites: [] };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (!arg.startsWith('--')) continue;
@@ -91,6 +92,14 @@ function parseArgs(argv) {
       case 'subclass': args.subclass = value; break;
       case 'feat':
       case 'feats': args.feats.push(...splitMultiflag(value)); break;
+      case 'archetype':
+      case 'archetypes': args.archetypes.push(...splitMultiflag(value)); break;
+      case 'set':
+      case 'setarg':
+      case 'setargs':
+      case 'kwargs':
+      case 'overwrite':
+      case 'overwrites': args.overwrites.push(value); break;
       case 'language': args.language = value; break;
       case 'out': args.out = value; break;
       case 'render': args.render = true; break;
@@ -113,6 +122,7 @@ function parseArgs(argv) {
       "druid": "untamed"
     },
     "feats": ["diehard"],
+    "archetypes": [],
     "language": "en"
   },
 */
@@ -157,6 +167,12 @@ function attributesForIdentity(identity, config, game) {
   // feats
   if (identity.feats && identity.feats.length) {
     attributes.feats = identity.feats;
+  }
+
+  // archetypes
+  if (identity.archetypes && identity.archetypes.length) {
+    const archetypeSlot = findSlot(data, 'archetype');
+    attributes.archetypes = identity.archetypes.map(code => resolveValue(archetypeSlot, code).id);
   }
 
   // language
@@ -260,8 +276,18 @@ function main() {
   }
   if (args.language) identity.language = args.language;
   if (args.feats.length) identity.feats = args.feats;
+  if (args.archetypes.length) identity.archetypes = args.archetypes;
 
   const attributes = attributesForIdentity(identity, config, game);
+
+  // overwrite any field in the attributes via key=value after the flag 
+  args.overwrites.forEach(raw => {
+    const eq = raw.indexOf('=');
+    const key = raw.slice(0, eq);
+    const value = raw.slice(eq + 1);
+    attributes[key] = value;
+  });
+
   const name = args.out || identity.name || game;
 
   const request = {
@@ -343,6 +369,5 @@ main().catch(err => {
     }
   }
 }
-
 
 */

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -1,14 +1,38 @@
 #!/usr/bin/env node
 
-// node test/generate-character.js [flags]
-// --game, --name, --ancestry, --heritage, --background, --subclass, --language, --out
-// --class (alias: --classes) --feat (alias: --feats) --archetype (alias: --archetypes)
-// --class druid|cleric <or> --class druid,cleric <or> --class druid --class cleric
-// --kwargs key=value | overwrite any attribute
-// --render | create test/out/<name>.html
-// --open | autoopen rendered file 
-// --no-build | no library rebuild (faster if no changes)
-// --list <subgroup> | list all valid values for ancestry/heritage/background/class/subclass/archetype/language
+// node test/generate-character.js --<flags>
+// node generate --flag1 arg1,arg2,arg3,...,argN --flag2 arg
+// via npm: npm run generate -- --flag1 arg1 --flag2 arg2
+//          (the "--" before the flags is required, otherwise npm swallows them)
+//
+// accepted separators: , ; |
+//
+// single-arg:
+// --name <arg>                           | --name Alex
+//
+// multi-arg:
+// --ancestry                             | --ancestry elf
+// --heritage                             | --heritage half-elf
+// --background                           | --background noble
+// --class                                | --class oracle,cleric          // two files, one per class
+//                                        | --class oracle --class cleric  // same as above
+// --feat                                 | --feat diehard,toughness     
+// --archetype                            | --archetype wizard,fighter  
+// --language                             | --language en,fr,it
+// --game                                 | --game pathfinder2,pathfinder2remaster
+//
+// --subclass                             | works like --class but is limited to the subclasses of
+//                                          a single class (needs exactly one --class to be picked)
+//
+// --limit <integer>                      | limit the number of files that can generate at once above default
+// --kwargs key=value                     | overwrite any attribute
+// --render                               | create test/out/html/<filename>.html
+// --open                                 | autoopen rendered file
+// --out <name>                           | when only one file is generated, this replaces the filename
+//                                          when multiple values generate fileS, it's a prefix instead
+// --no-build                             | no library rebuild (faster if no changes)
+// --list <subgroup>                      | list all valid values for 
+//                                          ancestry/heritage/background/class/subclass/archetype/language
 
 const fs = require('fs');
 const path = require('path');
@@ -18,7 +42,11 @@ const REPO_ROOT = path.join(__dirname, '..');
 const LIB_DIR = path.join(REPO_ROOT, 'lib');
 const IN_DIR = path.join(__dirname, 'in');
 const OUT_DIR = path.join(__dirname, 'out');
+const JSON_DIR = path.join(OUT_DIR, 'json');
+const HTML_DIR = path.join(OUT_DIR, 'html');
 const CONFIG_PATH = path.join(__dirname, 'generate-character.config.json');
+
+const DEFAULT_LIMIT = 200;
 
 function loadConfig() {
   return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
@@ -49,8 +77,26 @@ function resolveValue(slot, input) {
     || slot.values.find(v => removeTranslationKey(v.name).toLowerCase() === needle);
 }
 
+function resolveOrExit(slot, input, label) {
+  const value = resolveValue(slot, input);
+  if (!value) {
+    console.error(`generate-character: unknown ${label} "${input}"`);
+    process.exit(1);
+  }
+  return value;
+}
+
 function resolveLanguage(data, input) {
   return data.languages.find(l => l.code === input);
+}
+
+function resolveLanguageOrExit(data, input) {
+  const value = resolveLanguage(data, input);
+  if (!value) {
+    console.error(`generate-character: unknown language "${input}"`);
+    process.exit(1);
+  }
+  return value;
 }
 
 function subclassSlotsOf(classValue) {
@@ -72,7 +118,15 @@ function listSlotValues(slot, label) {
 }
 
 function splitMultiflag(value) {
-  return value.split(/[|,]/);
+  return value.split(/[,;|]/);
+}
+
+// classic cartesian product
+function cartesian(axesValues) {
+  return axesValues.reduce(
+    (combos, values) => combos.flatMap(combo => values.map(value => [...combo, value])),
+    [[]],
+  );
 }
 
 const BOOLEAN_FLAGS = new Set([
@@ -82,7 +136,18 @@ const BOOLEAN_FLAGS = new Set([
 ]);
 
 function parseArgs(argv) {
-  const args = { feats: [], classes: [], archetypes: [], kwargs: [] };
+  const args = {
+    feats: [],
+    classes: [],
+    archetypes: [],
+    kwargs: [],
+    games: [],
+    subclasses: [],
+    ancestries: [],
+    heritages: [],
+    backgrounds: [],
+    languages: [],
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (!arg.startsWith('--')) continue;
@@ -97,46 +162,39 @@ function parseArgs(argv) {
     }
 
     switch (key) {
-      case 'game': args.game = value; break;
+      case 'game':
+      case 'games': args.games.push(...splitMultiflag(value)); break;
       case 'name': args.name = value; break;
-      case 'ancestry': args.ancestry = value; break;
-      case 'heritage': args.heritage = value; break;
-      case 'background': args.background = value; break;
+      case 'ancestry':
+      case 'ancestries': args.ancestries.push(...splitMultiflag(value)); break;
+      case 'heritage':
+      case 'heritages': args.heritages.push(...splitMultiflag(value)); break;
+      case 'background':
+      case 'backgrounds': args.backgrounds.push(...splitMultiflag(value)); break;
       case 'class':
       case 'classes': args.classes.push(...splitMultiflag(value)); break;
-      case 'subclass': args.subclass = value; break;
+      case 'subclass':
+      case 'subclasses': args.subclasses.push(...splitMultiflag(value)); break;
       case 'feat':
       case 'feats': args.feats.push(...splitMultiflag(value)); break;
       case 'archetype':
       case 'archetypes': args.archetypes.push(...splitMultiflag(value)); break;
+      case 'kwarg':
       case 'kwargs': args.kwargs.push(value); break;
-      case 'language': args.language = value; break;
+      case 'language':
+      case 'languages': args.languages.push(...splitMultiflag(value)); break;
       case 'out': args.out = value; break;
       case 'list': args.list = value; break;
+      case 'limit': args.limit = parseInt(value, 10); break;
       case 'render': args.render = true; break;
       case 'open': args.open = true; break;
       case 'no-build': args.noBuild = true; break;
       default: console.error(`generate-character: unknown flag --${key}`); process.exit(1);
     }
   }
+
   return args;
 }
-
-/*
-  "identity": {
-    "name": "",
-    "ancestry": "human",
-    "heritage": "versatile",
-    "background": "noble",
-    "classes": ["druid"],
-    "subclasses": {
-      "druid": "untamed"
-    },
-    "feats": ["diehard"],
-    "archetypes": [],
-    "language": "en"
-  },
-*/
 
 // trying not to create a separate attribute for every 
 // subset of differently names subclasses, so the script
@@ -149,21 +207,21 @@ function attributesForIdentity(identity, config, game) {
   attributes.name = identity.name || game;
 
   // ancestry
-  const ancestryValue = resolveValue(findSlot(data, 'ancestry'), identity.ancestry);
+  const ancestryValue = resolveOrExit(findSlot(data, 'ancestry'), identity.ancestry, 'ancestry');
   attributes.ancestry = ancestryValue.id;
 
   // heritage
   const heritageSlotName = (ancestryValue.selects || []).find(name => name.startsWith('heritage/'));
   if (heritageSlotName) {
-    const heritageValue = resolveValue(findSlot(data, heritageSlotName), identity.heritage);
+    const heritageValue = resolveOrExit(findSlot(data, heritageSlotName), identity.heritage, 'heritage');
     attributes[heritageSlotName] = heritageValue.id;
   }
 
   // background
-  attributes.background = resolveValue(findSlot(data, 'background'), identity.background).id;
+  attributes.background = resolveOrExit(findSlot(data, 'background'), identity.background, 'background').id;
 
   // class
-  const classValues = identity.classes.map(code => resolveValue(findSlot(data, 'class'), code));
+  const classValues = identity.classes.map(code => resolveOrExit(findSlot(data, 'class'), code, 'class'));
   attributes.classes = classValues.map(cv => cv.id);
 
   // subclass,
@@ -172,7 +230,7 @@ function attributesForIdentity(identity, config, game) {
     if (!subclassSlotName) return;
     const subclassCode = identity.subclasses[removeRemasterPrefix(classValue.code)];
     if (!subclassCode) return;
-    attributes[subclassSlotName] = resolveValue(findSlot(data, subclassSlotName), subclassCode).id;
+    attributes[subclassSlotName] = resolveOrExit(findSlot(data, subclassSlotName), subclassCode, 'subclass').id;
   });
 
   // feats
@@ -183,32 +241,15 @@ function attributesForIdentity(identity, config, game) {
   // archetypes
   if (identity.archetypes && identity.archetypes.length) {
     const archetypeSlot = findSlot(data, 'archetype');
-    attributes.archetypes = identity.archetypes.map(code => resolveValue(archetypeSlot, code).id);
+    attributes.archetypes = identity.archetypes.map(code => resolveOrExit(archetypeSlot, code, 'archetype').id);
   }
 
   // language
-  attributes.language = resolveLanguage(data, identity.language).code;
+  attributes.language = resolveLanguageOrExit(data, identity.language).code;
 
   return attributes;
 }
 
-// config.identity plus whatever the CLI overwrites
-function buildIdentity(args, config) {
-  const identity = { ...config.identity };
-  if (args.name) identity.name = args.name;
-  if (args.ancestry) identity.ancestry = args.ancestry;
-  if (args.heritage) identity.heritage = args.heritage;
-  if (args.background) identity.background = args.background;
-  if (args.classes.length) identity.classes = args.classes;
-  if (args.subclass) {
-    const classCode = identity.classes[0];
-    identity.subclasses = { ...identity.subclasses, [classCode]: args.subclass };
-  }
-  if (args.language) identity.language = args.language;
-  if (args.feats.length) identity.feats = args.feats;
-  if (args.archetypes.length) identity.archetypes = args.archetypes;
-  return identity;
-}
 
 // apply kwargs into the attributes object
 function applyKwargs(attributes, kwargs) {
@@ -236,10 +277,15 @@ function buildRequest(attributes) {
 // this creates the .json request file to then render
 // the character sheet, following the same conventions the site does
 function writeRequestFile(name, request) {
-  const outFile = path.join(IN_DIR, `${name}.json`);
+  fs.mkdirSync(JSON_DIR, { recursive: true });
+  const outFile = path.join(JSON_DIR, `${name}.json`);
   fs.writeFileSync(outFile, JSON.stringify(request, null, 2));
   console.log(`Wrote ${path.relative(process.cwd(), outFile)}`);
 }
+
+// TBD: filter/group by certain character traits more easily (???)
+// TBD: add support for multiclassing and multiple types of the 
+// same attribute being parsed as a single character at once
 
 // send the rebuild to existing build script
 function rebuildLibrary(noBuild) {
@@ -297,7 +343,8 @@ function saveResult(result, openFlag) {
     return;
   }
 
-  const outfile = path.join(OUT_DIR, result.filename);
+  fs.mkdirSync(HTML_DIR, { recursive: true });
+  const outfile = path.join(HTML_DIR, result.filename);
   fs.writeFileSync(outfile, result.data);
   console.log(`Rendered ${path.relative(process.cwd(), outfile)}`);
   
@@ -332,11 +379,11 @@ function runList(args, game) {
   }
 
   if (args.list === 'heritage') {
-    if (!args.ancestry) {
-      console.error('generate-character: --list heritage needs --ancestry');
+    if (args.ancestries.length !== 1) {
+      console.error('generate-character: --list heritage needs exactly one --ancestry');
       process.exit(1);
     }
-    const ancestryValue = resolveValue(findSlot(data, 'ancestry'), args.ancestry);
+    const ancestryValue = resolveOrExit(findSlot(data, 'ancestry'), args.ancestries[0], 'ancestry');
     const heritageSlotName = ancestryValue.selects.find(n => n.startsWith('heritage/'));
     listSlotValues(findSlot(data, heritageSlotName), `heritage (${removeTranslationKey(ancestryValue.name)})`);
     return;
@@ -347,7 +394,7 @@ function runList(args, game) {
       console.error('generate-character: --list subclass needs exactly one --class');
       process.exit(1);
     }
-    const classValue = resolveValue(findSlot(data, 'class'), args.classes[0]);
+    const classValue = resolveOrExit(findSlot(data, 'class'), args.classes[0], 'class');
     const slotNames = subclassSlotsOf(classValue);
     if (slotNames.length === 0) {
       console.log(`${removeTranslationKey(classValue.name)} has no subclass slot`);
@@ -365,86 +412,167 @@ function runList(args, game) {
   process.exit(1);
 }
 
+function checkSubclassNeedsOneClass(classVariants, identityClasses, subclassSpecs) {
+  if (!subclassSpecs.length) return;
+
+  const classCount = classVariants.length === 1 && classVariants[0] === null
+    ? identityClasses.length
+    : classVariants.length;
+  if (classCount !== 1) {
+    console.error('generate-character: --subclass needs exactly one class, via --class or a single-class config default');
+    process.exit(1);
+  }
+}
+
+function resolveGames(args, config) {
+  return args.games.length ? args.games : [config.game];
+}
+
+function buildVariants(args, identity) {
+  return {
+    ancestryVariants: args.ancestries.length ? args.ancestries : [identity.ancestry],
+    heritageVariants: args.heritages.length ? args.heritages : [identity.heritage],
+    backgroundVariants: args.backgrounds.length ? args.backgrounds : [identity.background],
+    languageVariants: args.languages.length ? args.languages : [identity.language],
+    classVariants: args.classes.length ? args.classes : [null],
+    featVariants: args.feats.length ? args.feats : [null],
+    archetypeVariants: args.archetypes.length ? args.archetypes : [null],
+  };
+}
+
+// subclass depends on which class it's paired with
+function buildCombos(games, variants, identity, args) {
+  const {
+    ancestryVariants, heritageVariants, backgroundVariants, languageVariants,
+    classVariants, featVariants, archetypeVariants,
+  } = variants;
+
+  checkSubclassNeedsOneClass(classVariants, identity.classes, args.subclasses);
+
+  const independentCombos = cartesian([
+    games, ancestryVariants, heritageVariants, backgroundVariants,
+    languageVariants, featVariants, archetypeVariants,
+  ]);
+
+  const combos = [];
+  classVariants.forEach(classValue => {
+    const subclassCodes = args.subclasses.length ? args.subclasses : [null];
+    subclassCodes.forEach(subclassCode => {
+      independentCombos.forEach(([
+        game, ancestry, heritage, background, language, featValue, archetypeValue,
+      ]) => {
+        combos.push({
+          game, ancestry, heritage, background, language, classValue, subclassCode, featValue, archetypeValue,
+        });
+      });
+    });
+  });
+  return combos;
+}
+
+function checkComboLimit(combos, limit) {
+  if (combos.length > limit) {
+    console.error(`generate-character: this would generate ${combos.length} new charsheets. Increase the limit to proceed.`);
+    process.exit(1);
+  }
+}
+
+function computeMultiFlags(combos) {
+  const multiOf = key => new Set(combos.map(c => c[key])).size > 1;
+  return {
+    game: multiOf('game'),
+    ancestry: multiOf('ancestry'),
+    heritage: multiOf('heritage'),
+    background: multiOf('background'),
+    language: multiOf('language'),
+    classValue: multiOf('classValue'),
+    subclassCode: multiOf('subclassCode'),
+    featValue: multiOf('featValue'),
+    archetypeValue: multiOf('archetypeValue'),
+  };
+}
+
+function comboIdentityFor(combo, identity) {
+  const comboIdentity = {
+    ...identity,
+    ancestry: combo.ancestry,
+    heritage: combo.heritage,
+    background: combo.background,
+    language: combo.language,
+  };
+  if (combo.classValue) comboIdentity.classes = [combo.classValue];
+  if (combo.featValue) comboIdentity.feats = [combo.featValue];
+  if (combo.archetypeValue) comboIdentity.archetypes = [combo.archetypeValue];
+  if (combo.subclassCode) {
+    const classCode = combo.classValue || identity.classes[0];
+    comboIdentity.subclasses = { ...identity.subclasses, [classCode]: combo.subclassCode };
+  }
+  return comboIdentity;
+}
+
+// single file: --out replaces the name outright; multiple files: --out is just a prefix
+function nameForCombo(combo, args, identity, multi, multiFlags) {
+  if (!multi) {
+    return args.out || identity.name || combo.game;
+  }
+
+  // generate the filenames based on parts that consitute characters
+  const parts = [args.out || 'char'];
+  if (multiFlags.game) parts.push(combo.game);
+  if (multiFlags.ancestry) parts.push(combo.ancestry);
+  if (multiFlags.heritage) parts.push(combo.heritage);
+  if (multiFlags.background) parts.push(combo.background);
+  if (multiFlags.language) parts.push(combo.language);
+  if (multiFlags.classValue) parts.push(combo.classValue);
+  if (multiFlags.subclassCode) parts.push(combo.subclassCode);
+  if (multiFlags.featValue) parts.push(combo.featValue);
+  if (multiFlags.archetypeValue) parts.push(combo.archetypeValue);
+  return parts.join('-');
+}
+
+function buildRequests(combos, identity, config, args) {
+  const multi = combos.length > 1;
+  const multiFlags = computeMultiFlags(combos);
+
+  return combos.map(combo => {
+    const comboIdentity = comboIdentityFor(combo, identity);
+    const attributes = attributesForIdentity(comboIdentity, config, combo.game);
+    applyKwargs(attributes, args.kwargs);
+
+    const name = nameForCombo(combo, args, identity, multi, multiFlags);
+    return { name, request: buildRequest(attributes) };
+  });
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const config = loadConfig();
-  const game = args.game || config.game;
+  const games = resolveGames(args, config);
 
   if (args.list) {
-    runList(args, game);
+    runList(args, games[0]);
     return Promise.resolve();
   }
 
-  const identity = buildIdentity(args, config);
-  const attributes = attributesForIdentity(identity, config, game);
-  applyKwargs(attributes, args.kwargs);
+  const identity = { ...config.identity };
+  if (args.name) identity.name = args.name;
 
-  const name = args.out || identity.name || game;
-  const request = buildRequest(attributes);
-  writeRequestFile(name, request);
+  const variants = buildVariants(args, identity);
+  const combos = buildCombos(games, variants, identity, args);
+  checkComboLimit(combos, args.limit || DEFAULT_LIMIT);
+
+  const requests = buildRequests(combos, identity, config, args);
+  requests.forEach(({ name, request }) => writeRequestFile(name, request));
 
   if (!args.render) {
     return Promise.resolve();
   }
 
   rebuildLibrary(args.noBuild);
-  return renderToOut(request, args.open);
+  return requests.reduce((chain, { request }) => chain.then(() => renderToOut(request, args.open)), Promise.resolve());
 }
 
 main().catch(err => {
   console.error(err);
   process.exit(1);
 });
-
-/*
-
-{
-  "version": 0,
-  "data": {
-    "type": "character",
-    "id": "8fa82c7",
-    "isLoggedIn": true,
-    "attributes": {
-      "game": "pathfinder2remaster",
-      "name": "Remaster",
-      "ancestry": "ancestry/remaster/human",
-      "heritage/human": "heritage/human/remaster/versatile",
-      "background": "background/noble",
-      "classes": [
-        "class/remaster/alchemist"
-      ],
-      "cleric/doctrine": "cleric/doctrine/remaster/warpriest",
-      "rogue/racket": "rogue/racket/ruffian",
-      "x/druid/order": "druid/order/remaster/leaf",
-      "witch/patron": "witch/patron/wilding-steward",
-      "wizard/thesis": "wizard/thesis/staff-nexus",
-      "wizard/school": "wizard/school/unified-magical-theory",
-      "archetypes": ["xxx/archetype/remaster/wizard"],
-      "inventoryStyle": "double",
-      "optionCover": true,
-      "optionPermission": true,
-      "optionReference": true,
-      "optionBuild": true,
-      "optionMinis": true,
-      "optionBackground": true,
-      "optionLevelUp": true,
-      "optionColourful": true,
-      "optionPfs": false,
-      "optionAncestryParagon": false,
-      "optionAutomaticBonusProgression": false,
-      "feats": [ "diehard" ],
-      "skillsGroup": true,
-      "skillActions": true,
-      "miniSize": "small",
-      "printColour": "#241428",
-      "accentColour": "#a6085e",
-      "printDyslexic": false,
-      "printDyslexie": true,
-      "printPortrait": "portraits/Gnome Noole.png",
-      "printLogo": "logos/pathfinder2e.png",
-      "printBackground": "backgrounds/paper3.jpg"
-    }
-  }
-}
-
-*/

--- a/test/generate-character.js
+++ b/test/generate-character.js
@@ -121,7 +121,7 @@ function listSlotValues(slot, label) {
 }
 
 function splitMultiflag(value) {
-  return value.split(new RegExp(SEPARATORS));
+  return value.split(new RegExp(`[${SEPARATORS}]`));
 }
 
 // classic cartesian product


### PR DESCRIPTION
one-command explanation:

When working on the core2-barbarian branch, I was using variations of this command in order to make sure that all the subclass charsheets render correctly.

```bash
npm run generate -- --game pathfinder2 --class barbarian --subclass animal,dragon,fury,giant,spirit,supersition --render --open --page 4
```

Over a week, I eventually got myself to gather all the bits & pieces (and ideas) together to put all this into a single in-line tool. All the currently accepted (and hopefully, functional) flags are listed at the beginning of the file (and below). It should take the cartesian product of all possible ancestry/heritage/background/class/subclass/archetype/language–combinations that are listed in the config and generate a file for each of them and replace any config values by those user-parsed in-line via flags.

```js
// --name <arg>                           | --name Alex
//
// multi-arg:
// --ancestry                             | --ancestry elf
// --heritage                             | --heritage half-elf
// --background                           | --background noble
// --class                                | --class oracle,cleric          // two files, one per class
//                                        | --class oracle --class cleric  // same as above
// --feat                                 | --feat diehard,toughness     
// --archetype                            | --archetype wizard,fighter  
// --language                             | --language en,fr,it
// --game                                 | --game pathfinder2,pathfinder2remaster
//
// --subclass                             | works like --class but is limited to the subclasses of
//                                          a single class (needs exactly one --class to be picked)
//
// --limit <integer>                      | limit the number of files that can generate at once above default
// --kwargs key=value                     | overwrite any attribute
// --render                               | create test/out/html/<filename>.html
// --page                                 | only keep these pages (1 = the character page,
//                                          then combat/feats/class/etc) + 0, -1, -2... allow to
//                                          access pages before, may be non-consecutive: --page -1,2,6
// --open                                 | autoopen rendered file
// --out <name>                           | when only one file is generated, this replaces the filename
//                                          when multiple values generate fileS, it's a prefix instead
// --no-build                             | no library rebuild (faster if no changes)
// --list <subgroup>                      | list all valid values for 
//                                          ancestry/heritage/background/class/subclass/archetype/language
```

I'm certain there are more issues to solve because I have been testing the script on small sets of subclasses for one class, and the arguments are likely to clash if there are more of them. 

TO-DO: support multiclassing and archetypes somehow, together with generating multiple files at once — the approach I had in mind turned out to be too clunky. 