### PR TITLE
fix: make bloodline spells work as intended

### DIFF
--- a/lib/lib-charactersheets.js
+++ b/lib/lib-charactersheets.js
@@ -3901,7 +3901,7 @@ function spellField(lvl, style, checks, n, annotation, value) {
       return {};
   }
 }
-function spellLevel(lvl, ord, style, checks, slots, special, special_checks, special_value) {
+function spellLevel(lvl, ord, style, checks, slots, special, special_checks, special_value, special_index) {
   // log("spells", "Spell level:", lvl);
   var level_marker = {
     type: "level-marker",
@@ -3930,7 +3930,7 @@ function spellLevel(lvl, ord, style, checks, slots, special, special_checks, spe
   // number of spells
   var fields = [];
   if (special) {
-    special = makeSpecialField(special, 0);
+    special = makeSpecialField(special, special_index);
 
     // if (isString(special)) {
     //   // log("spells", "Adding special entry", special);
@@ -4091,7 +4091,7 @@ var spells_list = {
       }
 
       // log("spells-list", "Special value", ord, specialValues, "check", special_checks);
-      spell_levels.push(spellLevel(_lvl2, ord, args.style, args.checks, slots[_lvl2], args.special, special_checks, specialValues));
+      spell_levels.push(spellLevel(_lvl2, ord, args.style, args.checks, slots[_lvl2], args.special, special_checks, specialValues, _lvl2 - min));
     }
     return [{
       type: "list",

--- a/src/lib/elements/spells-list.js
+++ b/src/lib/elements/spells-list.js
@@ -65,7 +65,7 @@ function spellField(lvl, style, checks, n, annotation, value) {
   }
 }
 
-function spellLevel(lvl, ord, style, checks, slots, special, special_checks, special_value) {
+function spellLevel(lvl, ord, style, checks, slots, special, special_checks, special_value, special_index) {
   // log("spells", "Spell level:", lvl);
   const level_marker = {
     type: "level-marker",
@@ -91,7 +91,7 @@ function spellLevel(lvl, ord, style, checks, slots, special, special_checks, spe
   // number of spells
   let fields = [];
   if (special) {
-    special = makeSpecialField(special, 0);
+    special = makeSpecialField(special, special_index);
 
     // if (isString(special)) {
     //   // log("spells", "Adding special entry", special);
@@ -259,7 +259,7 @@ export let spells_list = {
       }
       
       // log("spells-list", "Special value", ord, specialValues, "check", special_checks);
-      spell_levels.push(spellLevel(lvl, ord, args.style, args.checks, slots[lvl], args.special, special_checks, specialValues));
+      spell_levels.push(spellLevel(lvl, ord, args.style, args.checks, slots[lvl], args.special, special_checks, specialValues, lvl - min));
     }
 
     return [


### PR DESCRIPTION
<img width="1008" height="642" alt="image" src="https://github.com/user-attachments/assets/b3376fdd-d647-47d4-afec-dbccaf13b665" />

Previously all bloodline spells were auto-filled with the level 1 spell name.