### PR TITLE
fix: un-merge spellbook level tag fields at the top of pages

### DIFF
--- a/src/units/pathfinder2remaster/player-core/option/spellbook/option-spellbook.yml
+++ b/src/units/pathfinder2remaster/player-core/option/spellbook/option-spellbook.yml
@@ -58,6 +58,7 @@ inc:
 
   - copy: spellbook/header
     params:
+      book: 0
       i: 0
     contents:
       - g:
@@ -65,7 +66,7 @@ inc:
           - row:
             contents:
               - spacer:
-              - field: spellbook-col-#{i}-level
+              - field: spellbook-#{book}/col-#{i}/level
                 border: full
                 frame: circle
                 label: "_{Spell Level}"
@@ -109,6 +110,7 @@ inc:
                 contents:
                   - paste: spellbook/header
                     params:
+                      book: 1
                       i: "#{i}"
           - layout: 3e
             contents:


### PR DESCRIPTION
<img width="803" height="275" alt="image" src="https://github.com/user-attachments/assets/9a596327-dfcd-4fbf-b36b-cfa5e00cc32c" />

If a class charsheet includes multiple spellbook pages, the level fields don't have different IDs, as discussed in Discord before. This PR addresses the bug 