### PR TITLE
Make landscape pages (familiar, construct, pet) export to PDF properly

### DIFF
--- a/src/units/common/document/stylesheet/_media-print.scss
+++ b/src/units/common/document/stylesheet/_media-print.scss
@@ -42,6 +42,9 @@ main {
 
   &.page--landscape {
     page: landscape;
+    min-height: 0;
+    max-height: none;
+    height: 100vw;
   }
 }
 

--- a/src/units/common/document/stylesheet/_media-print.scss
+++ b/src/units/common/document/stylesheet/_media-print.scss
@@ -8,6 +8,11 @@
 @page {
   margin: 0;
 }
+
+@page landscape {
+  size: landscape;
+}
+
 * {
   -webkit-print-color-adjust: exact !important;
   color-adjust: exact !important;
@@ -36,26 +41,7 @@ main {
   break-inside: avoid;
 
   &.page--landscape {
-    .page__contents {
-      -webkit-transform: rotate(-90deg);
-      -ms-transform: rotate(-90deg);
-      -o-transform: rotate(-90deg);
-      transform: rotate(-90deg);
-      transform-origin: left top;
-      width: 100vh;
-      height: 100vw;
-      overflow-x: hidden;
-      position: absolute;
-      top: 100%;
-      left: 0;
-      padding: 1cm;
-      box-sizing: border-box;
-
-      &:after {
-        top: 1cm;
-        bottom: 1cm;
-      }
-    }
+    page: landscape;
   }
 }
 


### PR DESCRIPTION
## Now

<img width="943" height="745" alt="image" src="https://github.com/user-attachments/assets/40d3e98b-ac94-4383-a12b-53b06e1143bd" />

## Previously
<img width="652" height="866" alt="image" src="https://github.com/user-attachments/assets/4fee1ab6-5e6e-4544-a83b-e91b668b5bc0" />

## Further

Might require further testing to see whether this prints/exports properly for everything, but I have much more faith in this than the version that had a part of it cut off
